### PR TITLE
Getting Started

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nova-oxide"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-smart-leds = "0.3.0"
-ws281x-rpi = "0.0.1"
+smart-leds = "0.4.0"
+# ws281x-rpi = "0.0.1" use self-compiled crate until this is updated
+ws281x-rpi = { path = "./ws281x-rpi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+smart-leds = "0.3.0"
+ws281x-rpi = "0.0.1"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# Variables
+WORKING_DIR = /home/pi/nova-oxide
+CARGO = /home/pi/.cargo/bin/cargo
+BINARY_PATH = /home/pi/nova-oxide/target/debug/nova-oxide
+
+# Build the project
+build:
+	rsync -r ./* pi:$(WORKING_DIR) --exclude=target/* --exclude=ws281x-rpi/target/*
+	ssh pi "cd $(WORKING_DIR) && $(CARGO) build"
+
+# Run the project
+run:
+	ssh -t pi "sudo $(BINARY_PATH)"
+
+# Build and run the project
+all: build run
+
+# Clean the build artifacts
+clean:
+	rm -rf target
+	ssh pi "cd $(WORKING_DIR) && rm -rf target"
+
+# Phony targets
+.PHONY: build run clean

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     // Additional OS configuration might be needed for any mode.
     // Check https://github.com/jgarff/rpi_ws281x for more information.
     const PIN: i32 = 18;
-    const NUM_LEDS: usize = 8;
+    const NUM_LEDS: usize = 308;
     const DELAY: time::Duration = time::Duration::from_millis(1000);
 
     let mut ws = Ws2812Rpi::new(NUM_LEDS as i32, PIN).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,58 @@
+use std::{thread, time};
+
+use smart_leds::{SmartLedsWrite, RGB8};
+use ws281x_rpi::Ws2812Rpi;
+
 fn main() {
-    println!("Hello, world!");
+    println!("Program start");
+
+    // GPIO Pin 10 is SPI
+    // Other modes and PINs are available depending on the Raspberry Pi revision
+    // Additional OS configuration might be needed for any mode.
+    // Check https://github.com/jgarff/rpi_ws281x for more information.
+    const PIN: i32 = 18;
+    const NUM_LEDS: usize = 8;
+    const DELAY: time::Duration = time::Duration::from_millis(1000);
+
+    let mut ws = Ws2812Rpi::new(NUM_LEDS as i32, PIN).unwrap();
+
+    let mut data: [RGB8; NUM_LEDS] = [RGB8::default(); NUM_LEDS];
+    let empty: [RGB8; NUM_LEDS] = [RGB8::default(); NUM_LEDS];
+
+    // Blink the LED's in a blue-green-red-white pattern.
+    for led in data.iter_mut().step_by(4) {
+        led.b = 32;
+    }
+
+    if NUM_LEDS > 1 {
+        for led in data.iter_mut().skip(1).step_by(4) {
+            led.g = 32;
+        }
+    }
+
+    if NUM_LEDS > 2 {
+        for led in data.iter_mut().skip(2).step_by(4) {
+            led.r = 32;
+        }
+    }
+
+    if NUM_LEDS > 3 {
+        for led in data.iter_mut().skip(3).step_by(4) {
+            led.r = 32;
+            led.g = 32;
+            led.b = 32;
+        }
+    }
+
+    loop {
+        // On
+        println!("LEDS on");
+        ws.write(data.iter().cloned()).unwrap();
+        thread::sleep(DELAY);
+
+        // Off
+        println!("LEDS off");
+        ws.write(empty.iter().cloned()).unwrap();
+        thread::sleep(DELAY);
+    }
 }


### PR DESCRIPTION
Uses the [code sample](https://github.com/smart-leds-rs/smart-leds-samples/blob/master/raspberry-pi-ws281x-rpi-examples/examples/raspberry_pi_ws281x_rpi_rgbw_blink.rs) from the smart-leds project to blind my strip/matrix of led's from my raspberry pi.

Once merged, this PR will:

1. [x] Allow me to build/run/clean simply via a Makefile
2. [x] Successfully blink all the LEDs on my neopixel strip arranged as a matrix 